### PR TITLE
Devel/huitema develop

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,20 @@
+* 2017-04-??: Version 1.1.0
+  * More fine grained control over TLS upstream retry and back off
+    behaviour with getdns_context_set_tls_backoff_time() and
+    getdns_context_set_tls_connection_retries().
+  * Feature: Round robin over the available upstreams
+    enable with getdns_context_set_round_robin_upstreams()
+  * Bugfix: Queue requests when no sockets available for outgoing queries.
+  * Obey the outstanding query limit with STUB resolution mode too.
+  * Updated stubby config file
+  * Basic draft MDNS client support
+    Thanks Christian Huitema
+  * bugfix: Let synchronous queries use fds > MAX_FDSETSIZE;
+            By moving default eventloop from select to poll
+    Thanks Neil Cook
+  * bugfix: authentication failure for self signed cert + only pinset
+  * bugfix: issue with session re-use making authentication appear to fail
+	
 * 2017-01-13: Version 1.0.0
   * edns0_cookies extension enabled by default (per RFC7873)
   * dnssec_roadblock_avoidance enabled by default (per RFC8027)

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,13 +2,13 @@
   * More fine grained control over TLS upstream retry and back off
     behaviour with getdns_context_set_tls_backoff_time() and
     getdns_context_set_tls_connection_retries().
-  * Feature: Round robin over the available upstreams
-    enable with getdns_context_set_round_robin_upstreams()
+  * New round robin over the available upstreams feaure.
+    Enable with getdns_context_set_round_robin_upstreams()
   * Bugfix: Queue requests when no sockets available for outgoing queries.
   * Obey the outstanding query limit with STUB resolution mode too.
   * Updated stubby config file
-  * Basic draft MDNS client support
-    Thanks Christian Huitema
+  * Draft MDNS client implementation by Christian Huitema.
+    Enable with --enable-draft-mdns-support to configure
   * bugfix: Let synchronous queries use fds > MAX_FDSETSIZE;
             By moving default eventloop from select to poll
     Thanks Neil Cook

--- a/Makefile.in
+++ b/Makefile.in
@@ -66,7 +66,6 @@ install: all getdns.pc getdns_ext_event.pc @INSTALL_GETDNS_QUERY@ @INSTALL_STUBB
 	$(INSTALL) -m 644 getdns_ext_event.pc $(DESTDIR)$(libdir)/pkgconfig
 	$(INSTALL) -m 755 -d $(DESTDIR)$(docdir)/spec
 	$(INSTALL) -m 644 $(srcdir)/spec/index.html $(DESTDIR)$(docdir)/spec
-	$(INSTALL) -m 644 $(srcdir)/spec/getdns*tgz $(DESTDIR)$(docdir)/spec || true
 	cd src && $(MAKE) $@
 	cd doc && $(MAKE) $@
 	@echo "***"
@@ -232,12 +231,13 @@ $(distdir):
 	cp $(srcdir)/src/test/*.good $(distdir)/src/test
 	cp $(srcdir)/src/compat/*.[ch] $(distdir)/src/compat
 	cp $(srcdir)/src/util/*.[ch] $(distdir)/src/util
+	cp -r $(srcdir)/src/util/orig-headers $(distdir)/src/util
+	cp -r $(srcdir)/src/util/auxiliary $(distdir)/src/util
 	cp $(srcdir)/src/gldns/*.[ch] $(distdir)/src/gldns
 	cp $(srcdir)/doc/Makefile.in $(distdir)/doc
 	cp $(srcdir)/doc/*.in $(distdir)/doc
 	cp $(srcdir)/doc/manpgaltnames $(distdir)/doc
 	cp $(srcdir)/spec/*.html $(distdir)/spec
-	cp $(srcdir)/spec/*.tgz $(distdir)/spec || true
 	cp $(srcdir)/spec/example/Makefile.in $(distdir)/spec/example
 	cp $(srcdir)/spec/example/*.[ch] $(distdir)/spec/example
 	cp $(srcdir)/src/tools/Makefile.in $(distdir)/src/tools

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Traditional access to DNS data from applications has several limitations:
 
 * Sophisticated uses of the DNS (things like IDNA and DNSSEC validation) require considerable application work, possibly by application developers with little experience with the vagaries of DNS.
 
-getdns also provides a experimental DNS Privacy enabled client called 'stubby' - see below for more details.
+getdns also provides an experimental DNS Privacy enabled client called 'stubby' - see below for more details.
 
 ## Motivation for providing the API
 
@@ -78,7 +78,7 @@ before building.
 As well as building the getdns library 2 other tools are installed by default by the above process:
 
 * getdns_query: a command line test script wrapper for getdns
-* stubby: a experimental DNS Privacy enabled client
+* stubby: an experimental DNS Privacy enabled client
 
 Note: If you only want to build stubby, then use the `--enable-stub-only` and `--without-libidn` options when running 'configure'.
 
@@ -344,6 +344,7 @@ Contributors
 * Robert Groenenberg
 * Paul Hoffman
 * Scott Hollenbeck, Verising, Inc.
+* Christian Huitema
 * Shumon Huque, Verisign Labs
 * Jelte Janssen
 * Guillem Jover
@@ -358,6 +359,7 @@ Contributors
 * Joel Purra
 * Tom Pusateri
 * Prithvi Ranganath, Verisign, Inc.
+* Hoda Rohani, NLnet Labs
 * Rushi Shah, Verisign, Inc.
 * Vinay Soni, Verisign, Inc.
 * Melinda Shore, No Mountain Software LLC

--- a/README.md
+++ b/README.md
@@ -197,18 +197,7 @@ Stub mode does not support:
 
 # Known Issues
 
-* The synchronous lookup functions will not work when new file descriptors
-  needed for the lookup will be larger than `FD_SETSIZE`.  This is because
-  the synchronous functions use a "default" event loop under the hood
-  which is based on `select()` and thus inherits the limits that `select()` has.
-
-  If you need only slightly more file descriptors, it is possible to enlarge
-  the `FD_SETSIZE` with the `--with-fd-setsize=`*`size`* flag to `configure`.
-
-  To resolve, use the asynchronous functions with an event loop extension for
-  libevent, libev or libuv.  Note that the asynchronous functions will have
-  the same problem when used in combination with `getdns_context_run()`, which
-  also uses the default event loop.
+* None
 
 # Supported Platforms
 
@@ -342,6 +331,7 @@ Contributors
 * Neel Goyal, Verisign, Inc.
 * Bryan Graham, Verisign, Inc.
 * Robert Groenenberg
+* Jim Hague, Sinodun
 * Paul Hoffman
 * Scott Hollenbeck, Verising, Inc.
 * Christian Huitema

--- a/configure.ac
+++ b/configure.ac
@@ -37,7 +37,7 @@ sinclude(./m4/ax_check_compile_flag.m4)
 sinclude(./m4/pkg.m4)
 
 AC_INIT([getdns], [1.1.0], [users@getdnsapi.net], [], [https://getdnsapi.net])
-AC_SUBST(RELEASE_CANDIDATE, [-alpha3])
+AC_SUBST(RELEASE_CANDIDATE, [-rc1])
 
 # Set current date from system if not set
 AC_ARG_WITH([current-date],
@@ -47,7 +47,7 @@ AC_ARG_WITH([current-date],
   [CURRENT_DATE="`date -u +%Y-%m-%dT%H:%M:%SZ`"])
 
 AC_SUBST(GETDNS_VERSION, ["AC_PACKAGE_VERSION$RELEASE_CANDIDATE"])
-AC_SUBST(GETDNS_NUMERIC_VERSION, [0x0100A300])
+AC_SUBST(GETDNS_NUMERIC_VERSION, [0x0100C100])
 AC_SUBST(API_VERSION, ["December 2015"])
 AC_SUBST(API_NUMERIC_VERSION, [0x07df0c00])
 GETDNS_COMPILATION_COMMENT="AC_PACKAGE_NAME $GETDNS_VERSION configured on $CURRENT_DATE for the $API_VERSION version of the API"

--- a/doc/Makefile.in
+++ b/doc/Makefile.in
@@ -77,6 +77,7 @@ uninstall:
 
 clean:
 	for x in $(MANPAGES3); do rm -f $$($(srcdir)/manpgaltnames $$x); done
+	rm -f tagfile
 	rm -rf $(DOCDIRS) $(MANPAGES3)
 
 distclean : clean

--- a/src/Doxyfile.in
+++ b/src/Doxyfile.in
@@ -1657,7 +1657,7 @@ TAGFILES               =
 # When a file name is specified after GENERATE_TAGFILE, doxygen will create
 # a tag file that is based on the input files it reads.
 
-GENERATE_TAGFILE       =
+GENERATE_TAGFILE       = ../doc/tagfile
 
 # If the ALLEXTERNALS tag is set to YES all external classes will be listed
 # in the class index. If set to NO only the inherited external classes

--- a/src/context.c
+++ b/src/context.c
@@ -756,7 +756,7 @@ _getdns_upstream_shutdown(getdns_upstream *upstream)
 	uint16_t conn_retries = upstream->upstreams->tls_connection_retries;
 	/* [TLS1]TODO: This arbitrary logic at the moment - review and improve!*/
 	if (upstream->conn_setup_failed >= conn_retries
-	    || (upstream->conn_shutdowns >= conn_retries*GETDNS_TRANSPORT_FAIL_MULT
+	    || ((int)upstream->conn_shutdowns >= conn_retries*GETDNS_TRANSPORT_FAIL_MULT
 	     && upstream->total_responses == 0)
 	    || (upstream->conn_completed >= conn_retries &&
 	     upstream->total_responses == 0 && 

--- a/src/context.c
+++ b/src/context.c
@@ -938,7 +938,7 @@ upstream_init(getdns_upstream *upstream,
 	upstream->keepalive_shutdown = 0;
 	upstream->keepalive_timeout = 0;
 	/* How is this upstream doing on UDP? */
-	upstream->to_retry =  2;
+	upstream->to_retry =  1;
 	upstream->back_off =  1;
 	upstream->udp_responses = 0;
 	upstream->udp_timeouts = 0;

--- a/src/context.c
+++ b/src/context.c
@@ -3569,10 +3569,12 @@ _get_context_settings(getdns_context* context)
 		return NULL;
 
 	/* int fields */
+	/* the timeouts are stored as uint64, but the value maximum used in
+	   practice is 6553500ms, so we just trim the value to be on the safe side. */
 	if (   getdns_dict_set_int(result, "timeout",
-	                           context->timeout)
+	                           (context->timeout > 0xFFFFFFFFull) ? 0xFFFFFFFF: (uint32_t) context->timeout)
 	    || getdns_dict_set_int(result, "idle_timeout",
-	                           context->idle_timeout)
+	                           (context->idle_timeout > 0xFFFFFFFFull) ? 0xFFFFFFFF : (uint32_t) context->idle_timeout)
 	    || getdns_dict_set_int(result, "limit_outstanding_queries",
 	                           context->limit_outstanding_queries)
             || getdns_dict_set_int(result, "dnssec_allowed_skew",

--- a/src/context.c
+++ b/src/context.c
@@ -756,7 +756,7 @@ _getdns_upstream_shutdown(getdns_upstream *upstream)
 	uint16_t conn_retries = upstream->upstreams->tls_connection_retries;
 	/* [TLS1]TODO: This arbitrary logic at the moment - review and improve!*/
 	if (upstream->conn_setup_failed >= conn_retries
-	    || (upstream->conn_shutdowns >= conn_retries*((unsigned)GETDNS_TRANSPORT_FAIL_MULT)
+	    || (upstream->conn_shutdowns >= conn_retries*GETDNS_TRANSPORT_FAIL_MULT
 	     && upstream->total_responses == 0)
 	    || (upstream->conn_completed >= conn_retries &&
 	     upstream->total_responses == 0 && 
@@ -3569,12 +3569,10 @@ _get_context_settings(getdns_context* context)
 		return NULL;
 
 	/* int fields */
-	/* the timeouts are stored as uint64, but the value maximum used in 
-	   practice is 6553500ms, so we just trim the value to be on the safe side. */
 	if (   getdns_dict_set_int(result, "timeout",
-		                       (context->timeout > 0xFFFFFFFFull)? 0xFFFFFFFF: (uint32_t) context->timeout)
+	                           context->timeout)
 	    || getdns_dict_set_int(result, "idle_timeout",
-		                       (context->idle_timeout > 0xFFFFFFFFull) ? 0xFFFFFFFF : (uint32_t) context->idle_timeout)
+	                           context->idle_timeout)
 	    || getdns_dict_set_int(result, "limit_outstanding_queries",
 	                           context->limit_outstanding_queries)
             || getdns_dict_set_int(result, "dnssec_allowed_skew",

--- a/src/general.c
+++ b/src/general.c
@@ -305,8 +305,13 @@ _getdns_netreq_change_state(
 	uint64_t now_ms;
 	getdns_network_req *prev;
 
-	if (!netreq || !netreq->owner->is_dns_request)
+	if (!netreq)
 		return;
+
+	if (!netreq->owner->is_dns_request) {
+		netreq->state = new_state;
+		return;
+	}
 
 	context = netreq->owner->context;
 

--- a/src/general.c
+++ b/src/general.c
@@ -585,12 +585,11 @@ getdns_general_ns(getdns_context *context, getdns_eventloop *loop,
 			/* Check whether the name belongs in the MDNS space */
 			if (!(r = _getdns_mdns_namespace_check(req)))
 			{
-				req->is_dns_request = 1;
+				req->is_dns_request = 0;
 				// Submit the query to the MDNS transport.
 				for (netreq_p = req->netreqs
 					; !r && (netreq = *netreq_p)
 					; netreq_p++) {
-					netreq->owner = req;
 					if ((r = _getdns_submit_mdns_request(netreq))) {
 						if (r == DNS_REQ_FINISHED) {
 							if (return_netreq_p)

--- a/src/getdns/getdns_extra.h.in
+++ b/src/getdns/getdns_extra.h.in
@@ -1027,7 +1027,8 @@ getdns_str2list(const char *str, getdns_list **list);
  *               - bindata representation of IP or IPv6 addresses may be
  *                 given in their presentation format.  For example:
  *                 `{ dns_root_servers: [ 2001:7fd::1, 193.0.14.129 ] }`
- *               - Arbitrary binary data may be given with a `0x` prefix.
+ *               - Arbitrary binary data may be given with a `0x` prefix,
+ *                 or in base64 encoding.
  *                 For example:
  *
  *                      { add_opt_parameters:
@@ -1044,7 +1045,7 @@ getdns_str2list(const char *str, getdns_list **list);
  *                        [ { address_data  : 2a04:b900:0:100::37
  *                          , tsig_name     : hmac-md5.tsigs.getdnsapi.net.
  *                          , tsig_algorithm: hmac-md5.sig-alg.reg.int.
- *                          , tsig_secret : 0xD7A1BAF4E4DE5D6EB149
+ *                          , tsig_secret : 16G69OTeXW6xSQ==
  *                          } ]
  *                      }
  *

--- a/src/getdns/getdns_extra.h.in
+++ b/src/getdns/getdns_extra.h.in
@@ -126,7 +126,6 @@ typedef enum getdns_tls_authentication_t {
 /** @}
   */
 
-
 /**
  * \defgroup Uvaluesandtextsdepricated Additional transport values and texts (will be deprecated)
  *  @{
@@ -226,15 +225,6 @@ getdns_context_run(getdns_context *context);
 /** @}
  */
 
-
-/**
- * \defgroup contextfunction Additional getdns_context async functions
- *  @{
- */
-/* process async reqs */
-getdns_return_t getdns_context_process_async(getdns_context* context);
-/** @}
- */
 
 /**
  * \defgroup Ucontextset Additional getdns_context_set functions
@@ -400,9 +390,6 @@ getdns_return_t
 getdns_context_get_update_callback(getdns_context *context, void **userarg,
     void (**value) (getdns_context *, getdns_context_code_t, void *));
 
-/* Async support */
-uint32_t getdns_context_get_num_pending_requests(getdns_context* context,
-    struct timeval* next_timeout);
 /** @}
  */
 
@@ -434,6 +421,8 @@ getdns_return_t getdns_dict_util_set_string(getdns_dict * dict,
 /* get a string from a dict.  the result must be freed if valid */
 getdns_return_t getdns_dict_util_get_string(getdns_dict * dict,
     char *name, char **result);
+
+
 
 /**
  * Validate replies or resource records.
@@ -521,6 +510,51 @@ getdns_return_t getdns_pubkey_pinset_sanity_check(
 	const getdns_list* pinset,
 	getdns_list* errorlist);
 
+/**
+ * Configure a context with settings given in a getdns_dict.
+ *
+ * @param  context The context to be configured.
+ * @param  config_dict The getdns_dict containing the settings.
+ *                     The settings have the same name as returned by the
+ *                     getdns_context_get_api_information() function, or as
+ *                     used in the names of the getdns_context_get_*() and
+ *                     getdns_context_set_*() functions.
+ *                     - The dict returned by
+ *                       getdns_context_get_api_information() can be used
+ *                       as the config_dict directly, but context settings
+ *                       do *not* have to be below a `"all_context"` key.
+ *                     - It is possible to set default values for extensions
+ *                       that could otherwise only be given on a per query
+ *                       basis.  For example:
+ *                       `{ dnssec_return_status: GETDNS_EXTENSION_TRUE }` is
+ *                       equivalent to using the
+ *                       getdns_context_set_return_dnssec_status() function
+ *                       with that value, but default values for the other 
+ *                       extensions can be set by this method now too.
+ *                       For example
+ *                       `{ return_call_reporting: GETDNS_EXTENSION_TRUE}`
+ *                     - Trust anchor files and root hints content can also be
+ *                       given by file, for example:
+ *
+ *                            { dns_root_servers : "named.root"
+ *                            , dnssec_trust_anchors: "/etc/unbound/getdns-root.key"
+ *                            }
+ * @return GETDNS_RETURN_GOOD on success or an error code on failure.
+ * **Beware** that context might be partially configured on error.  For retry
+ * strategies it is advised to recreate a new config.
+ */
+getdns_return_t
+getdns_context_config(getdns_context *context, const getdns_dict *config_dict);
+
+
+
+/** @}
+ */
+
+/**
+ * \defgroup UXTRAPrettyPrinting Pretty printing of getdns dicts and lists
+ *  @{
+ */
 
 /**
  * Pretty print the getdns_dict in a given buffer snprintf style.
@@ -616,6 +650,14 @@ int
 getdns_snprint_json_list(
     char *str, size_t size, const getdns_list *list, int pretty);
 
+
+/** @}
+ */
+
+/**
+ * \defgroup UDNSDataConversionFunctions Functions for converting between getdns DNS dicts, DNS wire format and DNS presentation format
+ *  @{
+ */
 
 /**
  * Convert rr_dict to wireformat representation of the resource record.
@@ -930,6 +972,14 @@ getdns_return_t
 getdns_msg_dict2str_scan(
     const getdns_dict *msg_dict, char **str, int *str_len);
 
+/** @}
+ */
+
+/**
+ * \defgroup Ustring2getdns_data Functions for converting strings to getdns data structures
+ *  @{
+ */
+
 /**
  * Convert string text to a getdns_dict.
  *
@@ -1018,42 +1068,13 @@ getdns_str2bindata(const char *str, getdns_bindata **bindata);
 getdns_return_t
 getdns_str2int(const char *str, uint32_t *value);
 
-/**
- * Configure a context with settings given in a getdns_dict.
- *
- * @param  context The context to be configured.
- * @param  config_dict The getdns_dict containing the settings.
- *                     The settings have the same name as returned by the
- *                     getdns_context_get_api_information() function, or as
- *                     used in the names of the getdns_context_get_*() and
- *                     getdns_context_set_*() functions.
- *                     - The dict returned by
- *                       getdns_context_get_api_information() can be used
- *                       as the config_dict directly, but context settings
- *                       do *not* have to be below a `"all_context"` key.
- *                     - It is possible to set default values for extensions
- *                       that could otherwise only be given on a per query
- *                       basis.  For example:
- *                       `{ dnssec_return_status: GETDNS_EXTENSION_TRUE }` is
- *                       equivalent to using the
- *                       getdns_context_set_return_dnssec_status() function
- *                       with that value, but default values for the other 
- *                       extensions can be set by this method now too.
- *                       For example
- *                       `{ return_call_reporting: GETDNS_EXTENSION_TRUE}`
- *                     - Trust anchor files and root hints content can also be
- *                       given by file, for example:
- *
- *                            { dns_root_servers : "named.root"
- *                            , dnssec_trust_anchors: "/etc/unbound/getdns-root.key"
- *                            }
- * @return GETDNS_RETURN_GOOD on success or an error code on failure.
- * **Beware** that context might be partially configured on error.  For retry
- * strategies it is advised to recreate a new config.
+/** @}
  */
-getdns_return_t
-getdns_context_config(getdns_context *context, const getdns_dict *config_dict);
 
+/**
+ * \defgroup UServerFunctions Functions for creating simple DNS servers
+ *  @{
+ */
 
 /**
  * The user defined request handler that will be called on incoming requests.
@@ -1133,6 +1154,13 @@ getdns_reply(getdns_context *context,
  * Please use getdns_get_errorstr_by_id instead of getdns_strerror.
  */
 getdns_return_t getdns_strerror(getdns_return_t err, char *buf, size_t buflen);
+
+getdns_return_t getdns_context_process_async(getdns_context* context);
+
+/* Async support */
+uint32_t getdns_context_get_num_pending_requests(getdns_context* context,
+    struct timeval* next_timeout);
+
 /** @}
  */
 /** @}

--- a/src/getdns/getdns_extra.h.in
+++ b/src/getdns/getdns_extra.h.in
@@ -77,11 +77,11 @@ extern "C" {
 #define GETDNS_CONTEXT_CODE_PUBKEY_PINSET 621
 #define GETDNS_CONTEXT_CODE_PUBKEY_PINSET_TEXT "Change related to getdns_context_set_pubkey_pinset"
 #define GETDNS_CONTEXT_CODE_ROUND_ROBIN_UPSTREAMS 622
-#define GETDNS_CONTEXT_CODE_ROUND_ROBIN_UPSTREAMS_TEXT "Change related to getdns_context_set_pubkey_pinset"
+#define GETDNS_CONTEXT_CODE_ROUND_ROBIN_UPSTREAMS_TEXT "Change related to getdns_context_set_round_robin_upstreams"
 #define GETDNS_CONTEXT_CODE_TLS_BACKOFF_TIME 623
-#define GETDNS_CONTEXT_CODE_TLS_BACKOFF_TIME_TEXT "Change related to getdns_context_set_pubkey_pinset"
+#define GETDNS_CONTEXT_CODE_TLS_BACKOFF_TIME_TEXT "Change related to getdns_context_set_tls_backoff_time"
 #define GETDNS_CONTEXT_CODE_TLS_CONNECTION_RETRIES 624
-#define GETDNS_CONTEXT_CODE_TLS_CONNECTION_RETRIES_TEXT "Change related to getdns_context_set_pubkey_pinset"
+#define GETDNS_CONTEXT_CODE_TLS_CONNECTION_RETRIES_TEXT "Change related to getdns_context_set_tls_connection_retries"
 /** @}
   */
 

--- a/src/mdns.c
+++ b/src/mdns.c
@@ -1589,7 +1589,7 @@ static getdns_return_t mdns_initialize_continuous_request(getdns_network_req *ne
 		{
 			GETDNS_CLEAR_EVENT(dnsreq->loop, &netreq->event);
 			GETDNS_SCHEDULE_EVENT(
-				dnsreq->loop, -1, dnsreq->context->timeout,
+				dnsreq->loop, -1, _getdns_ms_until_expiry(dnsreq->expires),
 				getdns_eventloop_event_init(&netreq->event, netreq,
 					NULL, NULL, mdns_mcast_timeout_cb));
 		}
@@ -1818,7 +1818,8 @@ mdns_udp_write_cb(void *userarg)
 		return;
 	}
 	GETDNS_SCHEDULE_EVENT(
-		dnsreq->loop, netreq->fd, dnsreq->context->timeout,
+		dnsreq->loop, netreq->fd,
+		_getdns_ms_until_expiry(dnsreq->expires),
 		getdns_eventloop_event_init(&netreq->event, netreq,
 			mdns_udp_read_cb, NULL, mdns_timeout_cb));
 }
@@ -1871,7 +1872,8 @@ _getdns_submit_mdns_request(getdns_network_req *netreq)
 		netreq->fd = fd;
 		GETDNS_CLEAR_EVENT(dnsreq->loop, &netreq->event);
 		GETDNS_SCHEDULE_EVENT(
-			dnsreq->loop, netreq->fd, dnsreq->context->timeout,
+			dnsreq->loop, netreq->fd,
+			_getdns_ms_until_expiry(dnsreq->expires),
 			getdns_eventloop_event_init(&netreq->event, netreq,
 				NULL, mdns_udp_write_cb, mdns_timeout_cb));
 		ret = GETDNS_RETURN_GOOD;

--- a/src/mdns.c
+++ b/src/mdns.c
@@ -1584,7 +1584,7 @@ static getdns_return_t mdns_initialize_continuous_request(getdns_network_req *ne
 		{
 			GETDNS_CLEAR_EVENT(dnsreq->loop, &netreq->event);
 			GETDNS_SCHEDULE_EVENT(
-				dnsreq->loop, -1, dnsreq->context->timeout*1000,
+				dnsreq->loop, -1, dnsreq->context->timeout,
 				getdns_eventloop_event_init(&netreq->event, netreq,
 					NULL, NULL, mdns_mcast_timeout_cb));
 		}
@@ -1813,7 +1813,7 @@ mdns_udp_write_cb(void *userarg)
 		return;
 	}
 	GETDNS_SCHEDULE_EVENT(
-		dnsreq->loop, netreq->fd, dnsreq->context->timeout*1000,
+		dnsreq->loop, netreq->fd, dnsreq->context->timeout,
 		getdns_eventloop_event_init(&netreq->event, netreq,
 			mdns_udp_read_cb, NULL, mdns_timeout_cb));
 }

--- a/src/mdns.c
+++ b/src/mdns.c
@@ -48,6 +48,11 @@ typedef u_short sa_family_t;
 #define TRUE 1
 #endif
 
+/* Define IPV6_ADD_MEMBERSHIP for FreeBSD and Mac OS X */
+#ifndef IPV6_ADD_MEMBERSHIP
+#define IPV6_ADD_MEMBERSHIP IPV6_JOIN_GROUP
+#endif
+
 uint64_t _getdns_get_time_as_uintt64();
 
 #include "util/fptr_wlist.h"

--- a/src/pubkey-pinning.c
+++ b/src/pubkey-pinning.c
@@ -382,7 +382,7 @@ _getdns_verify_pinset_match(const sha256_pin_t *pinset,
 			    X509_STORE_CTX *store)
 {
 	getdns_return_t ret = GETDNS_RETURN_GENERIC_ERROR;
-	X509 *x, *prev;
+	X509 *x, *prev = NULL;
 	int i, len;
 	unsigned char raw[4096];
 	unsigned char *next;

--- a/src/stub.c
+++ b/src/stub.c
@@ -600,10 +600,10 @@ stub_timeout_cb(void *userarg)
 #endif
 		netreq->upstream->udp_timeouts++;
 #if defined(DAEMON_DEBUG) && DAEMON_DEBUG
-	if (netreq->upstream->udp_timeouts % 100 == 0)
-		DEBUG_DAEMON("%s %-40s : Upstream stats: Transport=UDP - Resp=%d,Timeouts=%d\n",
-		             STUB_DEBUG_DAEMON, netreq->upstream->addr_str,
-		             (int)netreq->upstream->udp_responses, (int)netreq->upstream->udp_timeouts);
+		if (netreq->upstream->udp_timeouts % 100 == 0)
+			DEBUG_DAEMON("%s %-40s : Upstream stats: Transport=UDP - Resp=%d,Timeouts=%d\n",
+			             STUB_DEBUG_DAEMON, netreq->upstream->addr_str,
+			             (int)netreq->upstream->udp_responses, (int)netreq->upstream->udp_timeouts);
 #endif
 		stub_next_upstream(netreq);
 	} else {
@@ -1329,6 +1329,7 @@ _getdns_get_time_as_uintt64() {
 /* UDP callback functions */
 /**************************/
 
+
 static void
 stub_udp_read_cb(void *userarg)
 {
@@ -1348,8 +1349,28 @@ stub_udp_read_cb(void *userarg)
 	                                       */
 	    0, NULL, NULL);
 	if (read == -1 && _getdns_EWOULDBLOCK)
-		return;
+		return; /* Try again later */
 
+	if (read == -1) {
+		DEBUG_STUB("%s %-35s: MSG: %p error while reading from socket:"
+		           " %s\n", STUB_DEBUG_READ, __FUNC__, (void*)netreq
+			   , strerror(errno));
+
+		stub_cleanup(netreq);
+		_getdns_netreq_change_state(netreq, NET_REQ_ERRORED);
+		/* Handle upstream*/
+		if (netreq->fd >= 0) {
+#ifdef USE_WINSOCK
+			closesocket(netreq->fd);
+#else
+			close(netreq->fd);
+#endif
+			stub_next_upstream(netreq);
+		}
+		netreq->debug_end_time = _getdns_get_time_as_uintt64();
+		_getdns_check_dns_req_complete(netreq->owner);
+		return;
+	}
 	if (read < GLDNS_HEADER_SIZE)
 		return; /* Not DNS */
 	
@@ -1871,9 +1892,10 @@ upstream_select(getdns_network_req *netreq)
 		    upstream->back_off)
 			upstream = &upstreams->upstreams[i];
 
-	upstream->back_off++;
+	if (upstream->back_off > 1)
+		upstream->back_off--;
 	upstream->to_retry = 1;
-	upstreams->current_udp = (upstream - upstreams->upstreams) / GETDNS_UPSTREAM_TRANSPORTS;
+	upstreams->current_udp = upstream - upstreams->upstreams;
 	return upstream;
 }
 

--- a/src/test/check_getdns.c
+++ b/src/test/check_getdns.c
@@ -30,7 +30,10 @@
 #include <string.h>
 #include <inttypes.h>
 #include <unistd.h>
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
 #include <check.h>
+#pragma clang diagnostic pop
 #include "getdns/getdns.h"
 #include "check_getdns_common.h"
 #include "check_getdns_address.h"

--- a/src/test/check_getdns_common.c
+++ b/src/test/check_getdns_common.c
@@ -29,7 +29,10 @@
 #include <stdlib.h>
 #include <string.h>
 #include <inttypes.h>
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
 #include <check.h>
+#pragma clang diagnostic pop
 #include "getdns/getdns.h"
 #include "config.h"
 #include "check_getdns_common.h"

--- a/src/test/check_getdns_context_set_timeout.h
+++ b/src/test/check_getdns_context_set_timeout.h
@@ -27,7 +27,10 @@
 #ifndef _check_getdns_context_set_timeout_h_
 #define _check_getdns_context_set_timeout_h_
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
 #include <check.h>
+#pragma clang diagnostic pop
 
 Suite *
 getdns_context_set_timeout_suite (void);

--- a/src/test/check_getdns_libev.c
+++ b/src/test/check_getdns_libev.c
@@ -41,7 +41,10 @@
 #else
 #include <ev.h>
 #endif
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
 #include <check.h>
+#pragma clang diagnostic pop
 #include "check_getdns_common.h"
 
 void run_event_loop_impl(struct getdns_context* context, void* eventloop) {

--- a/src/test/check_getdns_libevent.c
+++ b/src/test/check_getdns_libevent.c
@@ -37,7 +37,10 @@
 
 #include "getdns/getdns_ext_libevent.h"
 #include "check_getdns_libevent.h"
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
 #include <check.h>
+#pragma clang diagnostic pop
 #include "check_getdns_common.h"
 
 void run_event_loop_impl(struct getdns_context* context, void* eventloop) {

--- a/src/test/check_getdns_libuv.c
+++ b/src/test/check_getdns_libuv.c
@@ -37,7 +37,10 @@
 
 #include "getdns/getdns_ext_libuv.h"
 #include <uv.h>
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
 #include <check.h>
+#pragma clang diagnostic pop
 #include "check_getdns_common.h"
 
 void run_event_loop_impl(struct getdns_context* context, void* eventloop) {

--- a/src/test/check_getdns_transport.h
+++ b/src/test/check_getdns_transport.h
@@ -27,7 +27,10 @@
 #ifndef _check_getdns_transport_h_
 #define _check_getdns_transport_h_
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
 #include <check.h>
+#pragma clang diagnostic pop
 
 Suite *
 getdns_transport_suite (void);

--- a/src/ub_loop.h
+++ b/src/ub_loop.h
@@ -43,18 +43,20 @@
 #include "debug.h"
 
 #ifdef HAVE_UNBOUND_EVENT_H
-#include <unbound-event.h>
+# include <unbound-event.h>
 #else
 struct ub_event_base_vmt;
 struct ub_event_base {
 	unsigned long magic;
         struct ub_event_base_vmt* vmt;
 };
-struct ub_event_base;
+# ifndef _UB_EVENT_PRIMITIVES
+#  define _UB_EVENT_PRIMITIVES
 struct ub_ctx* ub_ctx_create_ub_event(struct ub_event_base* base);
 typedef void (*ub_event_callback_t)(void*, int, void*, int, int, char*);
 int ub_resolve_event(struct ub_ctx* ctx, const char* name, int rrtype,
         int rrclass, void* mydata, ub_event_callback_t callback, int* async_id);
+# endif
 #endif
 
 typedef struct _getdns_ub_loop {

--- a/src/util-internal.c
+++ b/src/util-internal.c
@@ -862,7 +862,7 @@ _getdns_create_call_reporting_dict(
 				return NULL;
 			}
 		} else{
-			uint32_t idle_timeout = netreq->upstream->keepalive_timeout;
+			uint32_t idle_timeout = (uint32_t) netreq->upstream->keepalive_timeout;
 			if (getdns_dict_set_int( netreq_debug, "idle timeout in ms", idle_timeout)) {
 				getdns_dict_destroy(netreq_debug);
 				return NULL;

--- a/src/util-internal.c
+++ b/src/util-internal.c
@@ -862,7 +862,7 @@ _getdns_create_call_reporting_dict(
 				return NULL;
 			}
 		} else{
-			uint32_t idle_timeout = (uint32_t) netreq->upstream->keepalive_timeout;
+			uint32_t idle_timeout = netreq->upstream->keepalive_timeout;
 			if (getdns_dict_set_int( netreq_debug, "idle timeout in ms", idle_timeout)) {
 				getdns_dict_destroy(netreq_debug);
 				return NULL;


### PR DESCRIPTION
Christian, I made the mistake that netreq->state was not assigned when is_dns_request was not 1.
I believe this caused all your trouble.

I reverted some of your changes because they cannot be the cause of the failures you saw.  For example netreq->owner is assigned in request-internal.c:network_req_init() called when the getdns_dns_req is created with request-internal.c:_getdns_dns_req_new().

Also, the default event loop didn't change really.  But I do use a different method now with stub resolving.  The expiry time is now set by request-internal.c:_getdns_dns_req_new() too, and you may now use _getdns_ms_until_expiry(dnsreq->expires) to determine the timeout of a netreq.  I have changed mdns.c to use that.

Could you please check if this works for you?